### PR TITLE
Specify node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
       "prettier --single-quote --trailing-comma es5 --write",
       "git add"
     ]
+  },
+  "engines" : {
+     "node" : ">=4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utilita",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Utilities for JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Just to avoid any issues that could happen from using arrow functions in [node versions below 4 without the usage of correct flags](http://node.green/#ES2015-functions-arrow-functions-0-parameters), `engines` entry is added to display correct warnings.